### PR TITLE
update 01_intro and 02_packages

### DIFF
--- a/slides/01_intro.qmd
+++ b/slides/01_intro.qmd
@@ -225,8 +225,9 @@ knitr::include_graphics("resources/pkg_graph.png")
   Friedrich Pahlke [`r fontawesome::fa("github")`](https://github.com/fpahlke/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/pahlke/),
   Kevin Kunzmann [`r fontawesome::fa("github")`](https://github.com/kkmann/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/kevin-kunzmann-6486a11bb/)
 - In the current version, changes were done by (later authors):
-  * Liming Li [`r fontawesome::fa("github")`](https://github.com/clarkliming),
-  * Joe Zhu [`r fontawesome::fa("github")`](https://github.com/shajoezhu) [`r fontawesome::fa("linkedin")`](http://www.linkedin.com/in/joe-zhu-464b5818),
+  * Liming Li [`r fontawesome::fa("github")`](https://github.com/clarkliming)
+  * Joe Zhu [`r fontawesome::fa("github")`](https://github.com/shajoezhu) [`r fontawesome::fa("linkedin")`](http://www.linkedin.com/in/joe-zhu-464b5818), 
+  Shuang Li [`r fontawesome::fa("github")`](https://github.com/shuangli22)
 - This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
-- The source files are hosted at [github.com/pharmarug/pharmasug2024-r-workshop]( https://github.com/pharmarug/pharmasug2024-r-workshop), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe).
+- The source files are hosted at [github.com/pharmarug/pharmasug2025-r-workshop]( https://github.com/pharmarug/pharmasug2025-r-workshop), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe).
 - Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made

--- a/slides/02_r_packages.qmd
+++ b/slides/02_r_packages.qmd
@@ -322,7 +322,8 @@ export(my_sum)
 - Creators (initial authors): 
   Daniel Sabanes Bove [`r fontawesome::fa("github")`](https://github.com/danielinteractive/) [`r fontawesome::fa("linkedin")`](https://www.linkedin.com/in/danielsabanesbove/)
 - In the current version, changes were done by (later authors):
-  Liming Li [`r fontawesome::fa("github")`](https://github.com/clarkliming)
+  Liming Li [`r fontawesome::fa("github")`](https://github.com/clarkliming), 
+  Shuang Li [`r fontawesome::fa("github")`](https://github.com/shuangli22)
 - This work is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International License](http://creativecommons.org/licenses/by-sa/4.0/).
-- The source files are hosted at [github.com/pharmarug/pharmasug2024-r-workshop]( https://github.com/pharmarug/pharmasug2024-r-workshop), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe).
+- The source files are hosted at [github.com/pharmarug/pharmasug2025-r-workshop]( https://github.com/pharmarug/pharmasug2025-r-workshop), which is forked from the original version at [github.com/openpharma/workshop-r-swe](https://github.com/openpharma/workshop-r-swe).
 - Important: To use this work you must provide the name of the creators (initial authors), a link to the material, a link to the license, and indicate if changes were made


### PR DESCRIPTION
Hi @shajoezhu 

I have made minor update to the 01_intro and 02_packages.  And below is all the links need to be tested by the PharmaSug committee.

- https://shajoezhu.github.io/software/
- https://github.com/pharmarug/pharmasug2025-r-workshop
- https://posit.cloud/plans/free
- https://pharmaverse.org/
- https://r-pkgs.org/
- https://cran.r-project.org/doc/manuals/R-exts.html
- https://adv-r.hadley.nz/rcpp.html
- https://www.youtube.com/watch?v=fiy32LjgGUE
